### PR TITLE
Change address to London for Compound Partners role

### DIFF
--- a/jobs/compoundpartners.html
+++ b/jobs/compoundpartners.html
@@ -1,7 +1,7 @@
 ---
 title: Senior Django developer
 company: Compound Partners
-location: 70 High View Avenue, Essex, UK
+location: London, UK
 url: http://www.compoundpartners.co.uk/
 contract: permanent
 contact:


### PR DESCRIPTION
Thanks for updating the address to get this role listed! The address given is the founder's home address though, so I'm updating it to the more generic 'London, UK' as it appears Google will accept this. Hope that's OK. Thanks!