### PR TITLE
Update ClusterHQ_SeniorEngineer_perm_techfolk_2.html

### DIFF
--- a/jobs/ClusterHQ_SeniorEngineer_perm_techfolk_2.html
+++ b/jobs/ClusterHQ_SeniorEngineer_perm_techfolk_2.html
@@ -1,5 +1,5 @@
 ---
-title: Senior & Lead Software Engineer
+title: Lead Software Engineer: storage | containers | Docker
 company: ClusterHQ
 url: http://techfolk.co.uk/current-jobs/senior-software-engineer-central-bristol-tl69
 location: Bristol,United Kingdom
@@ -8,7 +8,7 @@ contact:
     name: Andrew Gifford
     email: hello@techfolk.co.uk
     phone: +44(0)117 318 2447
-created: !!timestamp '2015-06-22'
+created: !!timestamp '2015-09-16'
 tags:
   - Bristol
   - England
@@ -31,42 +31,47 @@ tags:
   - Network programming
 ---
 
-Senior / Lead Software Engineer - ClusterHQ
+Lead Software Engineer
 
-Your challenge
+ClusterHQ needs you to help define, architect and build open source storage management software in the rapidly evolving domain of Docker and containerisation.
 
-ClusterHQ has just released Flocker v1.0, providing the data layer for Docker, and needs needs you to help define and build next generation software in the exciting and disruptive domain of containerisation.
+Our product Flocker makes it easier for engineers to meet the data portability requirements of distributed, microservices-based applications, supporting container ecosystems such as Docker.
 
-This is your chance to be part of something new, where you can have a voice and be recognised for defining and building new cloud technology. Containers will impact infrastructure, application architecture and software delivery as fundamentally in the coming years as virtualisation has in the last decade. 
+We are a team of passionate software engineers, some of whom are leading lights in the open source world, and we're seeking a like-minded and experienced Lead Software Engineer for our teams in Bristol, UK and San Francisco in the US.
 
-You can lead on, or contribute to, product and technical architecture, software design, implementation, and mentoring and pairing with less experienced engineers.
+This is a key role in an exciting open source startup; as Lead Software Engineer you will help us to shape innovative container data products, define application architecture, design and build applications, and mentor and support our engineering teams.
 
-We code in Python and Go using asynchronous frameworks, and you can transfer from another language. It’s TDD and pair programming in small SCRUM teams, enjoying easy knowledge share with your colleagues in development, devops and quality assurance.
+We’re solving hard problems which involve customers’ data, so quality has to be at the heart of everything we do. We believe that test-driven development and continuous integration, code reviews and pair programming are the way to build high quality software.
 
-ClusterHQ is offering relocation to Bristol, UK, which is fast becoming the cloud computing hub of Europe and is renowned for its high quality of life.
+We're offering relocation to Bristol, UK, which is fast becoming the cloud computing hub of Europe and is renowned for its high quality of life.
 
-About you
+Example upcoming projects:
 
-- You’re ready for a progressive role as a Senior Developer, Technical Lead or Architect
-- You’re skilled in event-driven asynchronous programming 
-- You bring knowledge – commercial or open source - of domains such as: networking, cloud, clustering, virtualisation, storage, middleware, OS development, orchestration, micro services, containers etc.
-- You work openly and inclusively, and you enjoy code reviews and sharing ideas
-- You have advanced coding skills, using languages such as: C/C++ | Erlang | Go | Golang | Haskell | Java | Python | Scala | Ruby | etc.
-- You may have encountered technologies such as: Docker | Kubernetes | CoreOS | Oracle Coherence | Node.JS | Tornado | gevent | Twisted | Tulip| Klein | Netty | Java Message Server | JMS | Java Spaces | asyncio | AKKA | ScalaAsync | EventMachine | Async.io | Atmosphere | Autobahn | Apache Camel | Asio | OpenVZ etc.
+Building out the core Flocker product to support large scale production deployment
+Adding innovative new tools and services to enable container-based software delivery
+Integrating with leading container software and storage solutions
 
-Salary and benefits
+About you:
 
-- Competitive joining salary
-- Equity in a fast growing 
-- Discretionary relocation assistance
-- Flexible working | 28 days holiday + public holidays | pension | death in service | income protection | private healthcare | dental care | Cyclescheme | good coffee | on site restaurant
+You share our enthusiasm for quality code, TDD, pair programming, CI and helping others
+You're happy to code in Python and Go using the Twisted framework, transferring from: C / C++ | Erlang | Golang | Haskell | Java | Node.js | Perl | Python | Ruby | Scala | etc.
+You bring knowledge, commercial and/or open source, of domains such as: cloud engineering, networking, middleware, OS development, IaaS, PaaS, distributed systems, converged systems, virtualisation, clustering, storage, containers, orchestration, microservices, etc.
+You may have encountered technologies such as: Docker | Mesosphere | Marathon | Kubernetes | CoreOS | etcd | fleet | rkt | Oracle Coherence | Giant Swarm | LXC | Linux VServer | OpenVZ Virtuozzo | KVM | JVM | hypervisors | virtual machines | Ceph | libvirt | SDN | nginx | etc.
+You may have used frameworks such as: AKKA | Apache Camel | Asio | Async.io | asyncio | Atmosphere | Autobahn | BOOST | EventMachine | gevent | Java Message Server | JMS | Java Spaces | Klein | Netty | ScalaAsync | Neutron | Twisted | Tornado | Tulip | etc.
 
-About us
+Salary and benefits:
 
-ClusterHQ is a newly funded open source software provider, front and centre of the containerisation world. With five years in R&D and substantial funding from Accel Partners, we’ve just released our first product, Flocker, supporting the Docker ecosystem. Effective software design is at the heart of our organisation and fundamental to our future. Our global team includes accomplished open source contributors on projects such as Twisted and OpenZFS. We invite you to join our world class engineering teams.
+£70,000 – £100,000+ (negotiable)
+Equity in a fast growing company
+Discretionary relocation assistance
+Flexible working | 28 days holiday + public holidays | pension | death in service | income protection | private healthcare | dental care | Cyclescheme | good coffee | on site restaurant
 
-Located: central Bristol, South West UK, 1:45 by train from London
+About us:
+
+ClusterHQ provides the tools and services necessary for deploying and managing fully containerised stateful applications, simplifying IT processes and delivering on the advantages inherent in containers. We are the Container Data People™. Our engineering team includes accomplished open source contributors, from projects such as Twisted and OpenZFS. We invite you to join us, working on important and topical projects where you can have a voice and be recognised for your work.
+
+Located: central Bristol, near Temple Meads station; 1:45 by train to London
 
 Please talk with techfolk, our recruitment partner, to find out more:
-
 +44 (0)117 318 2447 | hello@techfolk.co.uk | @we_are_techfolk
+

--- a/jobs/ClusterHQ_SeniorEngineer_perm_techfolk_2.html
+++ b/jobs/ClusterHQ_SeniorEngineer_perm_techfolk_2.html
@@ -1,7 +1,7 @@
 ---
-title: Lead Software Engineer: storage | containers | Docker
+title: Lead Software Engineer - storage | containers | Docker
 company: ClusterHQ
-url: http://techfolk.co.uk/current-jobs/senior-software-engineer-central-bristol-tl69
+url: http://techfolk.co.uk/current-jobs/lead-software-engineer-docker-storage-containers-bristol-tl117
 location: Bristol,United Kingdom
 contract: permanent
 contact:


### PR DESCRIPTION
Modified and updated, to reflect that we are now primarily targeting Lead engineers and to display salary details.

Thanks, Andrew