### PR TITLE
Replace & with and as a temporary work-around

### DIFF
--- a/jobs/tab_london_full_stack_developer_2016-07-07.html
+++ b/jobs/tab_london_full_stack_developer_2016-07-07.html
@@ -16,7 +16,7 @@ tags:
 
 # About Tab
 
-Tab is a young startup that mixes travel & fintech, and we’re backed by Y Combinator (the incubator/accelerator behind Airbnb, Dropbox and Twitch).
+Tab is a young startup that mixes travel and fintech, and we’re backed by Y Combinator (the incubator/accelerator behind Airbnb, Dropbox and Twitch).
 
 Tab powers bookings and payments for tourist businesses (like hostels, dive schools and surf lodges) in emerging countries. We like doing the hard stuff – that’s why we’re already working with 60+ currencies, across countries like Guatemala, Argentina and Peru.
 
@@ -28,14 +28,14 @@ Our experienced team have backgrounds in startups and finance and are alumni of 
 
 As a full-stack developer, you'll be working across our entire platform, from public-facing web apps, to internal tools, APIs, third-party systems & services, and our mobile apps.
 
-You'll be working on many different things! We are focussed on improving the experience for our business & traveller users, but we also care about system stability, supporting internal business intelligence tasks, event analysis and composing infrastructure that lets us deploy rapidly in a way we can trust.
+You'll be working on many different things! We are focussed on improving the experience for our business and traveller users, but we also care about system stability, supporting internal business intelligence tasks, event analysis and composing infrastructure that lets us deploy rapidly in a way we can trust.
 
-We mostly write Python but also do Java, Swift and JavaScript with React & React Native, on mobile and on the web.
+We mostly write Python but also do Java, Swift and JavaScript with React and React Native, on mobile and on the web.
 
 We're building quickly, so things change and requirements evolve, but we try to find the balance between predictable stability (relaxed calm) and rapid development (move-fast-break-things).
  
 # Benefits
-Competitive salary, generous equity & flexible hours.
+Competitive salary, generous equity and flexible hours.
 
 We're early-stage and nimble, so expect the freedom to make a big impact quickly.
 
@@ -45,7 +45,7 @@ We're looking for someone who:
 
 * is excited by the chance to build something new as part of a small team at an early-stage startup within a fun market
 * enjoys coding in multiple languages across different platforms
-* has experience with Unix, git, Postgres (SQL & ORM) and Redis
+* has experience with Unix, git, Postgres (SQL and ORM) and Redis
 * thinks every good feature deserves a unit test or two
 * believes in refactoring (tomorrow will come)
 * has opinions on product design


### PR DESCRIPTION
Currently our markdown compiliation seems to be a bit broken - ampersands are not getting converted to the correct HTML entity. As a quick fix I've got rid of a bunch of them - this should restore our RSS feed.