### PR TITLE
Ease building and serving for local development using docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright (C) 2018 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the MIT license
+
+# Base image
+FROM python:2.7-stretch
+
+# Start off with the most updated image possible
+RUN apt-get update && apt-get --yes dist-upgrade
+
+# Install non-PyPI dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes -V \
+        gatling \
+        git
+
+# Install app including dependencies, whitelist approach (size, anti-leak)
+COPY docker-entrypoint.sh /root/pythonjobs/
+COPY jobs/ /root/pythonjobs/jobs/
+WORKDIR /root/pythonjobs
+RUN git clone --depth 1 https://github.com/pythonjobs/template.git
+RUN pip install -r template/requirements.txt
+
+# Build website first time
+RUN template/build.py /root/pythonjobs/
+
+# Sync and serve website
+EXPOSE 80
+ENTRYPOINT ["/root/pythonjobs/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -159,7 +159,16 @@ Sure, here: http://www.seethestats.com/site/pythonjobs.github.io
 
 ### Can I run the site locally to preview my submission?
 
-The easiest way to preview your submission is to build the site locally. You can use almost the exact same process we use to build the site on your own PC:
+The easiest way to preview your submission is to build the site locally.
+If you have Docker and [docker-compose](https://docs.docker.com/compose/) installed, run
+
+```console
+$ docker-compose up
+```
+
+and browse to http://127.0.0.1/50080/ once it says it's serving.
+
+Alternatively, you can use almost the exact same process we use to build the site on your own PC:
 
 1. Install hyde - hyde.github.io <code>pip install hyde</code>
 2. Install fin - <code>pip install fin</code>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# Copyright (C) 2018 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the MIT license
+
+version: "3"
+
+services:
+  pythonjobs:
+    build: .
+    ports:
+      - 50080:80
+    volumes:
+      - ./jobs:/root/pythonjobs/jobs

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+# Copyright (C) 2018 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the MIT license
+
+set -e
+
+cd /root/pythonjobs
+
+# Sync potential changes done after building the image
+( cd template && git pull origin master )
+./template/build.py .
+
+# Be helpful about non-standard port/URL
+cat <<INFO_END
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+X                                                   X
+X   Starting to serve at  http://127.0.0.1:50080/   X
+X                                          ^^^      X
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+INFO_END
+
+gatling_params=(
+    -F  # no FTP
+    -S  # no SMB
+    -d  # enable directory listings
+    -c template/hyde/deploy  # dir to serve and change into
+)
+exec gatling "${gatling_params[@]}"


### PR DESCRIPTION
Happy to make adjustments, hope you like the approach overall.
License is up for discussion as well, seen MIT at the [template repo](https://github.com/pythonjobs/template).
Tested with docker-compose 1.20.1 on top of Docker 18.03.0.

Best, Sebastian