### PR TITLE
Fix timestamp in realrate-gmbh-senior-python...

### DIFF
--- a/jobs/realrate-gmbh-senior-python-developer.html
+++ b/jobs/realrate-gmbh-senior-python-developer.html
@@ -7,7 +7,7 @@ contract: permanent, part-time possible
 contact:
     name: Holger Bartel
     email: holger.bartel@realrate.ai
-created: !!timestamp 2018-04-25
+created: !!timestamp 2021-04-11
 tags:
   - python
   - back-end


### PR DESCRIPTION
Thanks @lordmauve for noticing! I somehow expected the `!!timestamp` syntax do magically insert the current timestamp.

Relates to https://github.com/pythonjobs/jobs/pull/413.